### PR TITLE
Adjust header navigation alignment

### DIFF
--- a/f/css/index.css
+++ b/f/css/index.css
@@ -15,9 +15,18 @@ footer {
 }
 
 header nav {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
+  overflow: auto;
+}
+
+header nav .left {
+  float: left;
+  margin-right: 15px;
+}
+
+header nav .right,
+header nav .username {
+  float: right;
+  margin-left: 15px;
 }
 
 footer p {

--- a/f/index.html
+++ b/f/index.html
@@ -9,10 +9,10 @@
 <body>
   <header>
     <nav>
-      <a href="#"><i class="fa-solid fa-trophy"></i>Leaderboard</a>
-      <a href="#"><i class="fa-solid fa-gift"></i>Offers</a>
+      <a class="left" href="#"><i class="fa-solid fa-trophy"></i>Leaderboard</a>
+      <a class="left" href="#"><i class="fa-solid fa-gift"></i>Offers</a>
       <a href="#"><i class="fa-solid fa-hand-holding-dollar"></i>Withdraw</a>
-      <a href="#"><i class="fa-solid fa-user-gear"></i>Account</a>
+      <a class="right" href="#"><i class="fa-solid fa-user-gear"></i>Account</a>
       <span class="username"><i class="fa-solid fa-user"></i>Player123</span>
     </nav>
   </header>


### PR DESCRIPTION
## Summary
- Float leaderboard and offers to the left in the header
- Float account (and username) to the right using new CSS classes

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689b38c99ef4832b927f6540edd84f75