### PR TITLE
Implement leaderboard retrieval endpoint

### DIFF
--- a/b/Controllers/Api/LeaderBoardController.cs
+++ b/b/Controllers/Api/LeaderBoardController.cs
@@ -22,7 +22,10 @@ namespace Bux.Controllers.Api
         }
 
         [HttpGet("lines")]
-        public async Task<ActionResult<GetLeaderBoardResponse>> GetLeaderboard(Db db, [FromServices] SessionService sessionService)
+        public async Task<ActionResult<GetLeaderBoardResponse>> GetLeaderboard(
+            Db db,
+            [FromServices] SessionService sessionService,
+            [FromQuery, Range(1, 1000)] int? limit)
         {
             const string METHOD_NAME = "GetLeaderboard()";
 
@@ -30,6 +33,32 @@ namespace Bux.Controllers.Api
             {
                 int userId = await sessionService.GetUserId(); // my user id
 
+                const int DEFAULT_LIMIT = 100;
+                const int MAX_LIMIT = 1000;
+                int effectiveLimit = Math.Clamp(limit ?? DEFAULT_LIMIT, 1, MAX_LIMIT);
+
+                var topBux = await db.BuxEarned
+                    .Include(be => be.User)
+                    .OrderByDescending(be => be.Amount)
+                    .Take(effectiveLimit)
+                    .ToListAsync();
+
+                var lines = topBux
+                    .Select(be => new LeaderBoardLine(be.User?.Name ?? string.Empty, be.Amount))
+                    .ToList();
+
+                var userEntry = await db.BuxEarned.FirstOrDefaultAsync(be => be.UserId == userId);
+
+                int myPlace = 0;
+                if (userEntry != null)
+                {
+                    myPlace = await db.BuxEarned.CountAsync(be => be.Amount > userEntry.Amount) + 1;
+                }
+
+                return await Task.FromResult(StatusCode(200, new GetLeaderBoardResponse(
+                    lines: lines,
+                    myPlace: myPlace
+                )));
 
             }
             catch (Exception ex)


### PR DESCRIPTION
## Summary
- fetch leaderboard entries ordered by Bux amount and include usernames
- compute logged in user's rank in the leaderboard
- allow limiting the number of leaderboard lines returned via query parameter

## Testing
- `apt-get install -y dotnet-sdk-9.0` *(fails: Unable to locate package dotnet-sdk-9.0)*
- `apt-get install -y dotnet-sdk-8.0`
- `dotnet build b/bux.csproj` *(fails: current .NET SDK does not support .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68a6e87578c8832b8da6cd4a1825f7d0