### PR TITLE
feat: add leaderboard page

### DIFF
--- a/f/css/leaderboard.css
+++ b/f/css/leaderboard.css
@@ -1,0 +1,16 @@
+.leaderboard-table {
+    width: 100%;
+    border-collapse: collapse;
+}
+
+.leaderboard-table th,
+.leaderboard-table td {
+    padding: 0.5rem;
+    border-bottom: 1px solid #ccc;
+    text-align: left;
+}
+
+.my-place {
+    margin-top: 1rem;
+    font-weight: bold;
+}

--- a/f/leaderboard.php
+++ b/f/leaderboard.php
@@ -3,27 +3,44 @@
 
 <head>
 <?php
-	include 'php/include.php'
+        include 'php/include.php'
 ?>
 
+    <link rel="stylesheet" href="css/leaderboard.css">
 </head>
 
 <body>
     <header>
 <?php
-	include 'php/header.php'
+        include 'php/header.php'
 ?>
     </header>
 
     <main>
-		<p> Leaderboard .... to do </p>
+        <h3>Leaderboard</h3>
+        <table id="leaderboard-table" class="leaderboard-table">
+            <thead>
+                <tr>
+                    <th>#</th>
+                    <th>User</th>
+                    <th>Bux</th>
+                </tr>
+            </thead>
+            <tbody id="leaderboard-body">
+                <tr>
+                    <td colspan="3">Loading...</td>
+                </tr>
+            </tbody>
+        </table>
+        <div id="my-place" class="my-place"></div>
     </main>
 
     <footer>
 <?php
-	include 'php/footer.php'
+        include 'php/footer.php'
 ?>
     </footer>
+    <script type="module" src="leaderboard.js"></script>
 </body>
 
 </html>

--- a/f/leaderboard.ts
+++ b/f/leaderboard.ts
@@ -1,0 +1,59 @@
+import { callGetData } from './api.js';
+
+interface LeaderBoardLine {
+    username: string;
+    buxAmount: number;
+}
+
+interface GetLeaderBoardResponse {
+    lines: LeaderBoardLine[];
+    myPlace: number;
+}
+
+async function loadLeaderboard(): Promise<void> {
+    const result = await callGetData<GetLeaderBoardResponse>('b/api/leaderboard/lines');
+    const tbody = document.getElementById('leaderboard-body');
+    const myPlaceElem = document.getElementById('my-place');
+
+    if (!tbody || !myPlaceElem) {
+        console.error('missing leaderboard elements');
+        return;
+    }
+
+    tbody.textContent = '';
+
+    if (result.response) {
+        result.response.lines.forEach((line, index) => {
+            const tr = document.createElement('tr');
+
+            const posTd = document.createElement('td');
+            posTd.textContent = String(index + 1);
+            tr.appendChild(posTd);
+
+            const userTd = document.createElement('td');
+            userTd.textContent = line.username;
+            tr.appendChild(userTd);
+
+            const buxTd = document.createElement('td');
+            buxTd.textContent = String(line.buxAmount);
+            tr.appendChild(buxTd);
+
+            tbody.appendChild(tr);
+        });
+
+        if (result.response.myPlace > 0) {
+            myPlaceElem.textContent = `Your place: ${result.response.myPlace}`;
+        }
+    } else {
+        const tr = document.createElement('tr');
+        const td = document.createElement('td');
+        td.colSpan = 3;
+        td.textContent = 'Unable to load leaderboard';
+        tr.appendChild(td);
+        tbody.appendChild(tr);
+    }
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+    loadLeaderboard();
+});


### PR DESCRIPTION
## Summary
- build leaderboard page to display top users and current user rank
- style leaderboard table and user placement message

## Testing
- `npm test`
- `dotnet test` *(fails: command not found, attempted install of dotnet-sdk-7.0 but package unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_68a6f420674c832bb6b46e5610558f03