### PR TITLE
Expose total bux endpoint and update header

### DIFF
--- a/b/Controllers/Api/UserController.cs
+++ b/b/Controllers/Api/UserController.cs
@@ -1,5 +1,7 @@
 ﻿using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
 using Bux.Controllers.Model.Api.UserController;
+using Bux.Dbo;
 using Bux.Sessionn;
 
 namespace Bux.Controllers.Api
@@ -32,6 +34,22 @@ namespace Bux.Controllers.Api
             var getUserResponse = new GetUserResponse(user.Name, user.Email, user.FirstName, user.LastName);
 
             return Ok(getUserResponse);
+        }
+
+        [HttpGet("get-total-bux-earned")]
+        public async Task<ActionResult<GetTotalBuxEarnedResponse>> GetTotalBuxEarned([FromServices] Db db)
+        {
+            var user = await sessionService.GetLoggedInUser();
+            if (user == null)
+            {
+                return Unauthorized("No user logged in");
+            }
+
+            var buxEarned = await db.BuxEarned.FirstOrDefaultAsync(b => b.UserId == user.Id);
+            double total = buxEarned?.Amount ?? 0;
+
+            var response = new GetTotalBuxEarnedResponse(total);
+            return Ok(response);
         }
     }
 }

--- a/b/Controllers/Model/Api/UserController/Model.cs
+++ b/b/Controllers/Model/Api/UserController/Model.cs
@@ -1,5 +1,5 @@
 ﻿namespace Bux.Controllers.Model.Api.UserController
 {
     public record GetUserResponse(string username, string userEmail, string firstName, string lastName);
-
+    public record GetTotalBuxEarnedResponse(double totalBux);
 }

--- a/f/api.ts
+++ b/f/api.ts
@@ -16,6 +16,10 @@ export interface GetUserResponse {
     lastName: string;
 }
 
+export interface GetTotalBuxEarnedResponse {
+    totalBux: number;
+}
+
 export interface Response<T> {
     response: T | null;
     status: number | null;
@@ -101,5 +105,10 @@ export async function callBrowserRegister(request: BrowserRegisterRequest): Prom
 
 export async function callGetUser(): Promise<Response<GetUserResponse>> {
     let response = await callGetData<GetUserResponse>('b/auth/get-user');
+    return response;
+}
+
+export async function callGetTotalBuxEarned(): Promise<Response<GetTotalBuxEarnedResponse>> {
+    let response = await callGetData<GetTotalBuxEarnedResponse>('b/api/user/get-total-bux-earned');
     return response;
 }

--- a/f/click_game.ts
+++ b/f/click_game.ts
@@ -1,4 +1,5 @@
 import { callGetData, callPostData, Response } from './api.js';
+import { updateTotalBux } from './header_footer.js';
 
 interface ClickResponse {
     buxAmount: number;
@@ -57,7 +58,6 @@ function showResultContainer(buxEarned: number) {
     }
 }
 
-
 hideResultContainer();
 //showResultContainer(5); //@@@@@@@@@@@@@@@@@@@@@@
 
@@ -80,12 +80,13 @@ clickButton.addEventListener("click", async () => {
 		const res = await callClick();
 		console.log('@@@@@@@@@@@@@@@@@@@@@@@@@@@@ cp 200: callClick');
 		console.dir(res.response); // log the response from backend
-		if (res.response) {
-			showCountButton(res.response.clicksCount);
+                if (res.response) {
+                        showCountButton(res.response.clicksCount);
             if (res.response.buxAmount > 0) {
                 showResultContainer(res.response.buxAmount)
+                updateTotalBux();
             }
-		}
+                }
 			
 	} catch (err) {
 		console.error("Error calling click-game API:", err);

--- a/f/guess_game.ts
+++ b/f/guess_game.ts
@@ -1,4 +1,5 @@
 import {callGetData, callPostData, Response} from './api.js';
+import { updateTotalBux } from './header_footer.js';
 
 
 interface ClickRequest {
@@ -113,6 +114,9 @@ guessButton.addEventListener("click", async () => {
         if (res.response) {
             showGuessButton();
             showResultContainer(res.response.isMatch, res.response.buxAmount)
+            if (res.response.buxAmount > 0) {
+                updateTotalBux();
+            }
         } else {
             throw new Error('mo response');
         }

--- a/f/header_footer.ts
+++ b/f/header_footer.ts
@@ -1,8 +1,26 @@
+import { callGetTotalBuxEarned } from './api.js';
+
 export function setRoBloxUser(username: string) {
     let elem = document.getElementById("header-user-name");
     if (elem !== null) {
         elem.textContent = username;
     } else {
         console.warn("could not find element");
+    }
+}
+
+export function setTotalBux(totalBux: number) {
+    let elem = document.getElementById("header-total-bux");
+    if (elem !== null) {
+        elem.textContent = String(totalBux);
+    } else {
+        console.warn("could not find total bux element");
+    }
+}
+
+export async function updateTotalBux() {
+    let res = await callGetTotalBuxEarned();
+    if (res.response) {
+        setTotalBux(res.response.totalBux);
     }
 }

--- a/f/main.ts
+++ b/f/main.ts
@@ -1,5 +1,5 @@
 import { callGetUser } from './api.js'
-import { setRoBloxUser } from './header_footer.js'
+import { setRoBloxUser, updateTotalBux } from './header_footer.js'
 
 async function displayCurrentUser() {
     let result = await callGetUser()
@@ -8,7 +8,7 @@ async function displayCurrentUser() {
     }
 }
 
-
 document.addEventListener("DOMContentLoaded", function () {
     displayCurrentUser();
+    updateTotalBux();
 });

--- a/f/php/header.php
+++ b/f/php/header.php
@@ -3,7 +3,7 @@
             <a href="index.html"><i class="fa-solid fa-house"></i> <span class="menu-item"> Home </span> </a>
             <a href="leaderboard.html"><i class="fa-solid fa-trophy"></i> <span class="menu-item"> Leaderboard </span> </a>
             <a href="offers.html"><i class="fa-solid fa-gift"></i> <span class="menu-item"> Offers </span> </a>
-            <a href="withdraw.html"><i class="fa-solid fa-hand-holding-dollar"></i> <span class="menu-item"> Withdraw </span> </a>
+            <a href="withdraw.html"><i class="fa-solid fa-hand-holding-dollar"></i> <span class="menu-item"> Withdraw </span> <span id="header-total-bux" class="menu-item"></span></a>
             </span>
 
             <span class="header-right">


### PR DESCRIPTION
## Summary
- add GET `/api/user/get-total-bux-earned` to fetch a user's total Bux
- show total Bux next to Withdraw in header and update it after games
- centralize `updateTotalBux` in `header_footer.ts` and reuse in game and main scripts

## Testing
- `dotnet test` *(fails: The current .NET SDK does not support targeting .NET 9.0)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a6fbfba8ec832bb275560438d7b371